### PR TITLE
Override `LocalValidatorFactoryBean` bean

### DIFF
--- a/src/main/java/com/hopper/config/ValidationConfig.java
+++ b/src/main/java/com/hopper/config/ValidationConfig.java
@@ -4,23 +4,22 @@
  */
 package com.hopper.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-
-import javax.validation.Validator;
 
 @Configuration
-public class WebConfig extends WebMvcConfigurerAdapter {
+public class ValidationConfig {
 
-    @Autowired
-    private MessageSource messageSource;
+    private final MessageSource messageSource;
+
+    public ValidationConfig(MessageSource messageSource) {
+        this.messageSource = messageSource;
+    }
 
     @Bean
-    public Validator validator() {
+    public LocalValidatorFactoryBean validator() {
         LocalValidatorFactoryBean factory = new LocalValidatorFactoryBean();
         factory.setValidationMessageSource(this.messageSource);
         return factory;

--- a/src/test/java/com/hopper/controller/ComponentControllerTest.java
+++ b/src/test/java/com/hopper/controller/ComponentControllerTest.java
@@ -5,6 +5,7 @@
 package com.hopper.controller;
 
 import com.hopper.config.InitializerConfig;
+import com.hopper.config.ValidationConfig;
 import com.hopper.initializer.FileProcessor;
 import com.hopper.initializer.ProjectCreationService;
 import org.junit.Test;
@@ -28,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(value = ComponentController.class, secure = false)
-@Import(InitializerConfig.class)
+@Import({InitializerConfig.class, ValidationConfig.class})
 public class ComponentControllerTest {
     @Autowired
     private MockMvc mvc;


### PR DESCRIPTION
`spring-boot` provides `ValidationAutoConfiguration`, the default
implementation use `messageInterpolator`. This commit introduce the
use of `validationMessageSource` instead.