### PR TITLE
Update tests to work on windows as well

### DIFF
--- a/src/test/java/com/hopper/initializer/creator/java/ApplicationClassCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/ApplicationClassCreatorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import com.hopper.initializer.creator.FileCreationOrder;
@@ -59,7 +60,7 @@ public class ApplicationClassCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path applicationPath = pathCaptor.getValue();
-        assertEquals("./src/test/java/com/hopper/ApplicationTest.java", applicationPath.toString());
+        assertEquals(Paths.get("./src/test/java/com/hopper/ApplicationTest.java"), applicationPath);
     }
     
     @Test

--- a/src/test/java/com/hopper/initializer/creator/java/ApplicationYamlCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/ApplicationYamlCreatorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import com.hopper.initializer.creator.FileCreationOrder;
 import com.hopper.initializer.model.ProjectCreation;
@@ -58,8 +59,8 @@ public class ApplicationYamlCreatorTest {
                 .build();
         srcFileCreator.create(request);
         verify(fileProcessor, times(1)).touch(this.fileCaptor.capture());
-        String path = this.fileCaptor.getValue().toString();
-        assertEquals(folder.getRoot().getAbsolutePath()+ApplicationYamlCreator.APPLICATION_YML_PATH, path);
+        Path path = this.fileCaptor.getValue();
+        assertEquals(Paths.get(folder.getRoot().getAbsolutePath()+ApplicationYamlCreator.APPLICATION_YML_PATH), path);
     }
     
     

--- a/src/test/java/com/hopper/initializer/creator/java/JavaIntegrationTestPackageCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/JavaIntegrationTestPackageCreatorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -80,6 +81,6 @@ public class JavaIntegrationTestPackageCreatorTest {
     }
     
     private List<String> paths(String ciadKey) {
-        return Lists.newArrayList("./src/acceptanceTest/java/com/hopper");
+        return Lists.newArrayList(Paths.get("./src/acceptanceTest/java/com/hopper").toString());
     }
 }

--- a/src/test/java/com/hopper/initializer/creator/java/JavaIntegrationTestSrcCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/JavaIntegrationTestSrcCreatorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import com.hopper.initializer.creator.FileCreationOrder;
 import com.hopper.initializer.model.ProjectCreation;
@@ -57,12 +58,12 @@ public class JavaIntegrationTestSrcCreatorTest {
         assertTrue(this.fileCaptor
             .getAllValues()
             .stream()
-            .map(File::getPath)
+            .map(File::toPath)
             .allMatch(this::srcIsCreatedUnderRootFolder));
     }
     
-    private boolean srcIsCreatedUnderRootFolder(String input) {
-        return input.equals(folder.getRoot().getPath()+"/src/acceptanceTest/java")
-               || input.equals(folder.getRoot().getPath()+"/src/acceptanceTest/resources");
+    private boolean srcIsCreatedUnderRootFolder(Path input) {
+        return input.equals(folder.getRoot().toPath().resolve("src/acceptanceTest/java"))
+               || input.equals(folder.getRoot().toPath().resolve("src/acceptanceTest/resources"));
     }
 }

--- a/src/test/java/com/hopper/initializer/creator/java/JavaMainSrcCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/JavaMainSrcCreatorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import com.hopper.initializer.FileProcessor;
 import com.hopper.initializer.creator.FileCreationOrder;
@@ -55,13 +56,13 @@ public class JavaMainSrcCreatorTest {
         assertTrue(this.fileCaptor
             .getAllValues()
             .stream()
-            .map(File::getPath)
+            .map(File::toPath)
             .allMatch(this::srcIsCreatedUnderRootFolder));
     }
     
-    private boolean srcIsCreatedUnderRootFolder(String input) {
-        return input.equals(folder.getRoot().getPath()+"/src/main/java")
-               || input.equals(folder.getRoot().getPath()+"/src/main/resources");
+    private boolean srcIsCreatedUnderRootFolder(Path input) {
+        return input.equals(folder.getRoot().toPath().resolve("src/main/java"))
+               || input.equals(folder.getRoot().toPath().resolve("src/main/resources"));
     }
 
 }

--- a/src/test/java/com/hopper/initializer/creator/java/JavaPackageCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/JavaPackageCreatorTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -55,16 +57,16 @@ public class JavaPackageCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(2)).createDirectories(fileCaptor.capture());
         
-        List<String> collectedPaths = fileCaptor.getAllValues()
+        List<Path> collectedPaths = fileCaptor.getAllValues()
                   .stream()
-                  .map(File::getPath)
+                  .map(File::toPath)
                   .collect(Collectors.toList());
         assertEquals(paths(request.getProjectKey()), collectedPaths);
         
     }
     
-    private List<String> paths(String ciadKey) {
-        return Lists.newArrayList("./src/main/java/com/hopper",
-                "./src/test/java/com/hopper");
+    private List<Path> paths(String ciadKey) {
+        return Lists.newArrayList(Paths.get("./src/main/java/com/hopper"),
+                Paths.get("./src/test/java/com/hopper"));
     }
 }

--- a/src/test/java/com/hopper/initializer/creator/java/JavaPackageCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/JavaPackageCreatorTest.java
@@ -61,11 +61,11 @@ public class JavaPackageCreatorTest {
                   .stream()
                   .map(File::toPath)
                   .collect(Collectors.toList());
-        assertEquals(paths(request.getProjectKey()), collectedPaths);
+        assertEquals(paths(), collectedPaths);
         
     }
     
-    private List<Path> paths(String ciadKey) {
+    private List<Path> paths() {
         return Lists.newArrayList(Paths.get("./src/main/java/com/hopper"),
                 Paths.get("./src/test/java/com/hopper"));
     }

--- a/src/test/java/com/hopper/initializer/creator/java/JavaTestSrcCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/JavaTestSrcCreatorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import com.hopper.initializer.creator.FileCreationOrder;
 import com.hopper.initializer.model.ProjectCreation;
@@ -56,13 +57,13 @@ public class JavaTestSrcCreatorTest {
         assertTrue(this.fileCaptor
             .getAllValues()
             .stream()
-            .map(File::getPath)
+            .map(File::toPath)
             .allMatch(this::srcIsCreatedUnderRootFolder));
     }
     
-    private boolean srcIsCreatedUnderRootFolder(String input) {
-        return input.equals(folder.getRoot().getPath()+"/src/test/java")
-               || input.equals(folder.getRoot().getPath()+"/src/test/resources");
+    private boolean srcIsCreatedUnderRootFolder(Path input) {
+        return input.equals(folder.getRoot().toPath().resolve("src/test/java"))
+               || input.equals(folder.getRoot().toPath().resolve("src/test/resources"));
     }
 
 }

--- a/src/test/java/com/hopper/initializer/creator/java/PackageInfoCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/PackageInfoCreatorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import com.hopper.initializer.creator.FileCreationOrder;
@@ -57,7 +58,7 @@ public class PackageInfoCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path path = pathCaptor.getValue();
-        assertEquals("./src/test/java/com/hopper/package-info.java", path.toString());
+        assertEquals(Paths.get("./src/test/java/com/hopper/package-info.java"), path);
     }
     
 }

--- a/src/test/java/com/hopper/initializer/creator/java/SpringbootApplicationTestClassCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/java/SpringbootApplicationTestClassCreatorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import com.hopper.initializer.creator.FileCreationOrder;
@@ -58,7 +59,7 @@ public class SpringbootApplicationTestClassCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path applicationPath = pathCaptor.getValue();
-        assertEquals("./src/main/java/com/hopper/Application.java", applicationPath.toString());
+        assertEquals(Paths.get("./src/main/java/com/hopper/Application.java"), applicationPath);
     }
     
     @Test

--- a/src/test/java/com/hopper/initializer/creator/node/ConfJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/node/ConfJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class ConfJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path confJsPath = pathCaptor.getValue();
-        assertEquals("./acceptanceTest/conf.js", confJsPath.toString());
+        assertEquals(Paths.get("./acceptanceTest/conf.js"), confJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/node/HealthCheckJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/node/HealthCheckJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class HealthCheckJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path healthCheckJsPath = pathCaptor.getValue();
-        assertEquals("./acceptanceTest/healthCheck.js", healthCheckJsPath.toString());
+        assertEquals(Paths.get("./acceptanceTest/healthCheck.js"), healthCheckJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/node/IndexJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/node/IndexJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class IndexJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path indexJsPath = pathCaptor.getValue();
-        assertEquals("./src/index.js", indexJsPath.toString());
+        assertEquals(Paths.get("./src/index.js"), indexJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/node/IndexSpecJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/node/IndexSpecJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class IndexSpecJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path indexJsPath = pathCaptor.getValue();
-        assertEquals("./test/index_spec.js", indexJsPath.toString());
+        assertEquals(Paths.get("./test/index_spec.js"), indexJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/node/PackageJsonCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/node/PackageJsonCreatorTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -50,7 +51,7 @@ public class PackageJsonCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path packageJsonPath = pathCaptor.getValue();
-        assertEquals("./package.json", packageJsonPath.toString());
+        assertEquals(Paths.get("./package.json"), packageJsonPath);
     }
     
     @Test

--- a/src/test/java/com/hopper/initializer/creator/react/AppJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/react/AppJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class AppJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path healthCheckJsPath = pathCaptor.getValue();
-        assertEquals("./src/App.js", healthCheckJsPath.toString());
+        assertEquals(Paths.get("./src/App.js"), healthCheckJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/react/AppSpecJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/react/AppSpecJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class AppSpecJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path healthCheckJsPath = pathCaptor.getValue();
-        assertEquals("./acceptanceTest/App_spec.js", healthCheckJsPath.toString());
+        assertEquals(Paths.get("./acceptanceTest/App_spec.js"), healthCheckJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/react/AppTestJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/react/AppTestJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class AppTestJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path appTestJsPath = pathCaptor.getValue();
-        assertEquals("./test/App.test.js", appTestJsPath.toString());
+        assertEquals(Paths.get("./test/App.test.js"), appTestJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/react/ConfJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/react/ConfJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class ConfJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path confJsPath = pathCaptor.getValue();
-        assertEquals("./acceptanceTest/conf.js", confJsPath.toString());
+        assertEquals(Paths.get("./acceptanceTest/conf.js"), confJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/react/IndexHtmlCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/react/IndexHtmlCreatorTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -48,7 +49,7 @@ public class IndexHtmlCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path indexHtmlPath = pathCaptor.getValue();
-        assertEquals("./src/index.html", indexHtmlPath.toString());
+        assertEquals(Paths.get("./src/index.html"), indexHtmlPath);
     }
     
     @Test

--- a/src/test/java/com/hopper/initializer/creator/react/IndexJsCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/react/IndexJsCreatorTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +64,7 @@ public class IndexJsCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path indexJsPath = pathCaptor.getValue();
-        assertEquals("./src/index.js", indexJsPath.toString());
+        assertEquals(Paths.get("./src/index.js"), indexJsPath);
     }
 
     @Test

--- a/src/test/java/com/hopper/initializer/creator/react/PackageJsonCreatorTest.java
+++ b/src/test/java/com/hopper/initializer/creator/react/PackageJsonCreatorTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -50,7 +51,7 @@ public class PackageJsonCreatorTest {
         this.creator.create(request);
         verify(this.fileProcessor, times(1)).touch(pathCaptor.capture());
         Path packageJsonPath = pathCaptor.getValue();
-        assertEquals("./package.json", packageJsonPath.toString());
+        assertEquals(Paths.get("./package.json"), packageJsonPath);
     }
     
     @Test


### PR DESCRIPTION
Currently the unit tests will only run successfully on linux/unix based environments, primarily due to the difference in the path separator on windows. This PR addresses this by:
- Making comparisons based on Path objects to avoid having to translate path separators (Path class internally handles this difference)
