### PR TITLE
Addressing bintray issues

### DIFF
--- a/artifact.json
+++ b/artifact.json
@@ -1,15 +1,15 @@
 {
   "package": {
-    "name": "accelerator-initializer",
+    "name": "Accelerator-Initializer",
     "repo": "PLATO-Open-Source",
     "subject": "yshewchuk",
     "desc": "Basic templating API",
-    "website_url": "github.com/scotiabank/accelerator-initializer",
+    "website_url": "https://github.com/scotiabank/accelerator-initializer",
     "issue_tracker_url": "https://github.com/scotiabank/accelerator-initializer/issues",
     "vcs_url": "https://github.com/scotiabank/accelerator-initializer.git",
     "github_use_tag_release_notes": true,
     "github_release_notes_file": "RELEASE.txt",
-    "licenses": ["MPL 2.0"],
+    "licenses": ["MPL-2.0"],
     "labels": [],
     "public_download_numbers": true,
     "public_stats": true,


### PR DESCRIPTION
Bintray deployment failed due to two errors in logs:
- License does not exist (was missing a hyphen to match defined OSS license)
- Package was not found (I think this may be case sensitive)