### PR TITLE
Update readme to reflect correct URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ http://localhost:8086/swagger-ui.html
 Or: 
 Use a tool to execute an HTTP POST request to
 ```
-http://localhost:8086/api/projects/components/download
+http://localhost:8086/api/project/generate
 ```
 
 Including one of the following in the request body:


### PR DESCRIPTION
Currently the readme contains the old URI for generating projects - addressing this.

Fixes #59