### PR TITLE
Enable build scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
   directories:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
-script: "./gradlew clean check prepareForPublish"
+script: "./gradlew clean check prepareForPublish --scan"
 deploy:
   provider: bintray
   file: "artifact.json"

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,16 @@
 plugins {
+    id 'com.gradle.build-scan' version '1.16'
     id 'java'
     id 'idea'
     id 'jacoco'
     id 'org.springframework.boot' version '2.0.4.RELEASE'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'maven-publish'
+}
+
+buildScan {
+    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+    licenseAgree = 'yes'
 }
 
 description 'Accelerator initializer - project generation API'


### PR DESCRIPTION
This commit enables gradle build scan which is published at the end of the build. In this PR, the url is https://gradle.com/s/jt63jb7iytxb2 which exposes build information in the different tasks. In order to perform this, we need to agreed the [terms of service](https://gradle.com/legal/terms-of-service/)